### PR TITLE
feat(midi): Handle noteon and cc events on enable

### DIFF
--- a/src/extra/midi-assignment/index.js
+++ b/src/extra/midi-assignment/index.js
@@ -92,12 +92,20 @@ const midiAssignment = {
         // the assignment is an internal control
         const type = data[1];
 
+        // The "enable" button for the module
         if (type === 'enable') {
-          const value = !!Math.round(Math.map(midiEvent.data[2], 0, 127, 0, 1));
-          store.commit('modVModules/setActiveModuleEnabled', {
-            moduleName,
-            enabled: value,
-          });
+          // Only listen for On-events (button pressed)
+          // 1. Controlchange
+          // 2. noteon
+          if ((midiEvent.data[2] > 63 && midiEvent.data[0] === 176) || midiEvent.data[0] === 144) {
+            const module = store.getters['modVModules/getActiveModule'](moduleName);
+            const enabled = module.info.enabled;
+
+            store.commit('modVModules/setActiveModuleEnabled', {
+              moduleName,
+              enabled: !enabled,
+            });
+          }
         } else if(type === 'alpha') { //eslint-disable-line
           const value = Math.map(midiEvent.data[2], 0, 127, 0, 1);
           store.commit('modVModules/setActiveModuleAlpha', {

--- a/src/extra/midi-assignment/index.js
+++ b/src/extra/midi-assignment/index.js
@@ -94,10 +94,21 @@ const midiAssignment = {
 
         // The "enable" button for the module
         if (type === 'enable') {
-          // Only listen for On-events (button pressed)
-          // 1. Controlchange
-          // 2. noteon
-          if ((midiEvent.data[2] > 63 && midiEvent.data[0] === 176) || midiEvent.data[0] === 144) {
+          /*
+           * Only listen for On-events (button pressed)
+           *
+           * data[0] defines the specific MIDI "action" that gets triggered based
+           * on which type the MIDI element has (for example a button might have
+           * the type "Note"). Based on this we can handle different actions
+           *
+           * 1. Controlchange
+           * - 176 = This is a Controlchange event
+           * - 63 = Only listen for "button pressed", because this is the velocity
+           *
+           * 2. NoteOn
+           * - 144 = This is a NoteOn event
+           */
+          if ((midiEvent.data[0] === 176 && midiEvent.data[2] > 63) || midiEvent.data[0] === 144) {
             const module = store.getters['modVModules/getActiveModule'](moduleName);
             const enabled = module.info.enabled;
 


### PR DESCRIPTION
Both handle NoteOn and CC-On events for the enable button, so that it can be used to activate /
deactivate a module