### PR TITLE
feat(grabCanvas): Small preview is black

### DIFF
--- a/src/extra/grab-canvas/index.js
+++ b/src/extra/grab-canvas/index.js
@@ -25,7 +25,7 @@ const smallContext = smallCanvas.getContext('2d');
 
 // Add the canvas to modV for testing purposes :D
 smallCanvas.classList.add('is-hidden');
-smallCanvas.style = 'position: absolute; top: 0px; right: 0px; width: 80px; height: 80px; z-index: 100000;';
+smallCanvas.style = 'position: absolute; top: 0px; right: 0px; width: 80px; height: 80px; z-index: 100000; background: #000;';
 document.body.appendChild(smallCanvas);
 
 const grabCanvas = {


### PR DESCRIPTION
Turned the background of the small preview window to black to be consistent with the other preview
windows

Fixes #185