### PR TITLE
fix(plugin): Label is visible

### DIFF
--- a/src/assets/styles/index.scss
+++ b/src/assets/styles/index.scss
@@ -366,3 +366,8 @@ input[disabled][type="range"]::-webkit-slider-runnable-track {
   background: rgba(255, 255, 255, .8);
   color: black;
 }
+
+.label {
+  color: inherit;
+  font-weight: normal;
+}


### PR DESCRIPTION
Changed the style of the label to use what the class on the actual parent element has to remove the
"default" color from the style lib in use.

Fixes #212