### PR TITLE
fix(slimui): Don't overlap reorder

### DIFF
--- a/src/extra/slim-ui/ControlPanel.vue
+++ b/src/extra/slim-ui/ControlPanel.vue
@@ -35,6 +35,13 @@
             display: inline-flex;
           }
         }
+
+        // Prevent the label to overlap reorder
+        .control-group {
+          > label {
+            min-width: 0;
+          }
+        }
       }
 
       // For every module in a layer:


### PR DESCRIPTION
Prevent the enable checkbox to overlap the reorder icon.

Fixes #213