### PR TITLE
fix(grab-canvas): Selected area is now correct

### DIFF
--- a/src/extra/grab-canvas/luminave-connector.js
+++ b/src/extra/grab-canvas/luminave-connector.js
@@ -211,7 +211,7 @@ export default class LuminaveConnector {
     const areaAmount = this.selectionX * this.selectionY;
 
     // Size of each area
-    const areaSize = (this.width / areaAmount) + (this.height / areaAmount);
+    const areaSize = Math.floor((this.width / areaAmount) + (this.height / areaAmount));
 
     // The packet that gets send over WebSocket to luminave
     const colors = [];


### PR DESCRIPTION
The selected area gets calculated corret now and is not too big. This was happening because a Float
was used for the areaSize, even when the result shshould always be an Integer.

Fixes #254