### PR TITLE
refactor(waveform): Remove legacy strict on strokeWeight

### DIFF
--- a/src/modv/sample-modules/Waveform-2.0.js
+++ b/src/modv/sample-modules/Waveform-2.0.js
@@ -16,7 +16,7 @@ export default {
       min: 1,
       max: 30,
       default: 1,
-      strict: true,
+      abs: true,
     },
 
     maxHeight: {


### PR DESCRIPTION
Using the property "strict" is outdated, so it was exchanged with "abs" which prevents the value to
go underneath 0, but makes it possible to increase the value of strokeWeight over the defined max of
30.

Fixes #308