### PR TITLE
feat(shadertoy iMouse): Removes iMouse as built-in uniform

### DIFF
--- a/src/modv/renderers/shader.js
+++ b/src/modv/renderers/shader.js
@@ -31,7 +31,6 @@ function render({ Module, canvas, context, pipeline }) {
     iChannel1: modVCanvasTexture,
     iChannel2: modVCanvasTexture,
     iChannel3: modVCanvasTexture,
-    iMouse: [0, 0, 0, 0],
   };
 
   if (Module.props) {
@@ -107,7 +106,6 @@ function makeProgram(Module) {
         viewportHeight,
         pixelRatio,
       ],
-      iMouse: regl.prop('iMouse'),
       iChannel0: regl.prop('iChannel0'),
       iChannel1: regl.prop('iChannel1'),
       iChannel2: regl.prop('iChannel2'),

--- a/src/modv/webgl/default-shader.js
+++ b/src/modv/webgl/default-shader.js
@@ -23,7 +23,6 @@ export default {
     uniform int       iFrame;                // shader playback frame
     uniform float     iChannelTime[4];       // channel playback time (in seconds)
     uniform vec3      iChannelResolution[4]; // channel resolution (in pixels)
-    uniform vec4      iMouse;                // mouse pixel coords. xy: current (if MLB down), zw: click
     uniform vec4      iDate;                 // (year, month, day, time in seconds)
     uniform sampler2D iChannel0;             // Texture #1
     uniform sampler2D iChannel1;             // Texture #2
@@ -57,7 +56,6 @@ export default {
     uniform int       iFrame;                // shader playback frame
     uniform float     iChannelTime[4];       // channel playback time (in seconds)
     uniform vec3      iChannelResolution[4]; // channel resolution (in pixels)
-    uniform vec4      iMouse;                // mouse pixel coords. xy: current (if MLB down), zw: click
     uniform vec4      iDate;                 // (year, month, day, time in seconds)
     uniform sampler2D iChannel0;             // Texture #1
     uniform sampler2D iChannel1;             // Texture #2


### PR DESCRIPTION
This adds the ability for the Shadertoy Plugin to define props for when iMouse is detected. As modV doesn't have a vec4 control method, it's up to the user to define a way to translate controls to vec4 uniforms. The Shadertoy Plugin is an example of this.

BREAKING CHANGE: Removes iMouse as a built-in uniform

re #170