### PR TITLE
feat(palettes): Adds palette restoration from presets

### DIFF
--- a/src/store/modules/palettes.js
+++ b/src/store/modules/palettes.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import { modV } from '@/modv';
+import store from '../index';
 
 const state = {
   palettes: {},
@@ -12,9 +13,20 @@ const getters = {
 
 // actions
 const actions = {
-  createPalette({ commit, state }, { id, colors, duration, moduleName, returnFormat, variable }) {
+  createPalette({ commit, state }, {
+    override,
+    id,
+    colors,
+    duration,
+    moduleName,
+    returnFormat,
+    variable,
+  }) {
     return new Promise((resolve) => {
-      if (id in state.palettes === true) resolve(state.palettes[id]);
+      if (id in state.palettes === true && !override) {
+        resolve(state.palettes[id]);
+        return;
+      }
 
       let colorsPassed = [];
       let durationPassed = 300;
@@ -88,6 +100,13 @@ const actions = {
     });
 
     return data;
+  },
+  async loadPreset({ actions }, { paletteData }) {
+    Object.keys(paletteData).forEach(async (id) => {
+      const palette = paletteData[id];
+
+      await store.dispatch('palettes/createPalette', { id, override: true, ...palette });
+    });
   },
 };
 

--- a/src/store/modules/projects.js
+++ b/src/store/modules/projects.js
@@ -103,6 +103,10 @@ const actions = {
         });
       });
 
+      if ('paletteData' in presetData) {
+        await store.dispatch('palettes/loadPreset', presetData);
+      }
+
       if ('pluginData' in presetData) {
         const pluginData = presetData.pluginData;
         const currentPlugins = store.state.plugins.plugins;


### PR DESCRIPTION
Although this was mentioned in an issue, an interface in modV didn't exist to load palette data from a preset. Something like this was present in the past but was lost when code was separated.

Hence this is being marked as a feature rather than a fix as its been so long.

re: #27