### PR TITLE
Updates travis.yml to use npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ before_install:
   - sudo dpkg --add-architecture i386
   - sudo apt-get update
   - sudo apt-get install wine
+install: npm install


### PR DESCRIPTION
This replaces the travis default 'npm ci' command instead which doesn't deal with npm installing itself as a package, needed by the media manager.