### PR TITLE
feat(feature-smoothing): adds a smoothing control for input links

### DIFF
--- a/src/application/index.js
+++ b/src/application/index.js
@@ -208,7 +208,9 @@ export default class ModV {
   }
 
   loop(delta) {
-    const { meyda: featuresToGet } = this.store.state;
+    const {
+      meyda: { features: featuresToGet }
+    } = this.store.state;
 
     const features = this.meyda.get(featuresToGet);
     this.updateBeatDetektor(delta, features);

--- a/src/application/worker/audio-features.js
+++ b/src/application/worker/audio-features.js
@@ -1,4 +1,8 @@
+const MAX_SMOOTHING = 2;
+const SMOOTHING_STEP = 0.001;
+
 let features = {};
+const smoothedFeatures = {};
 
 function getFeatures() {
   return features;
@@ -12,4 +16,37 @@ function setFeatures(newFeatures) {
   features = newFeatures;
 }
 
-export { getFeature, getFeatures, setFeatures };
+function addSmoothingId(id) {
+  smoothedFeatures[id] = 0;
+}
+
+function removeSmoothingId(id) {
+  delete smoothedFeatures[id];
+}
+
+function getSmoothedFeature(feature, id, smoothingValue) {
+  let value = smoothedFeatures[id];
+
+  if (features[feature] >= value) {
+    value = features[feature];
+  } else if (value - smoothingValue > 0) {
+    value -= smoothingValue;
+  } else {
+    value = features[feature];
+  }
+
+  smoothedFeatures[id] = value;
+
+  return value;
+}
+
+export {
+  getFeature,
+  getFeatures,
+  setFeatures,
+  addSmoothingId,
+  removeSmoothingId,
+  getSmoothedFeature,
+  MAX_SMOOTHING,
+  SMOOTHING_STEP
+};

--- a/src/application/worker/store/modules/inputs.js
+++ b/src/application/worker/store/modules/inputs.js
@@ -48,6 +48,10 @@ const actions = {
     return true;
   },
 
+  updateInputLink({ commit }, { inputId, key, value, writeToSwap }) {
+    commit("UPDATE_INPUT_LINK", { inputId, key, value, writeToSwap });
+  },
+
   removeInputLink({ commit }, { inputId, writeToSwap }) {
     const writeTo = writeToSwap ? swap : state;
 
@@ -113,6 +117,10 @@ const mutations = {
 
   UPDATE_INPUT_LINK(state, { inputId, key, value, writeToSwap }) {
     const writeTo = writeToSwap ? swap : state;
+
+    if (!writeTo.inputLinks[inputId]) {
+      return;
+    }
 
     Vue.set(writeTo.inputLinks[inputId], key, value);
   },

--- a/src/application/worker/store/modules/meyda.js
+++ b/src/application/worker/store/modules/meyda.js
@@ -1,32 +1,73 @@
-import { getFeature } from "../../audio-features";
+import {
+  getFeature,
+  addSmoothingId,
+  removeSmoothingId,
+  getSmoothedFeature,
+  MAX_SMOOTHING,
+  SMOOTHING_STEP
+} from "../../audio-features";
+import uuidv4 from "uuid/v4";
 
-const state = ["complexSpectrum"];
+const state = {
+  features: ["complexSpectrum"],
+  smoothingIds: [],
+  MAX_SMOOTHING,
+  SMOOTHING_STEP
+};
 
 const getters = {
-  getFeature: () => key => {
-    return getFeature(key);
+  getFeature: () => (feature, smoothingId, smoothingValue) => {
+    if (smoothingId && smoothingValue) {
+      return getSmoothedFeature(feature, smoothingId, smoothingValue);
+    }
+
+    return getFeature(feature);
   }
 };
 
 const actions = {
   addFeature({ commit }, feature) {
     commit("ADD_FEATURE", feature);
+  },
+
+  getSmoothingId() {
+    const id = uuidv4();
+    addSmoothingId(id);
+    return id;
+  },
+
+  // eslint-disable-next-line no-empty-pattern
+  removeSmoothingId({}, id) {
+    removeSmoothingId(id);
   }
 };
 
 const mutations = {
   ADD_FEATURE(state, feature) {
-    const index = state.indexOf(feature);
+    const index = state.features.indexOf(feature);
 
     if (index < 0) {
-      state.push(feature);
+      state.features.push(feature);
     }
   },
+
   REMOVE_FEATURE(state, feature) {
-    const index = state.indexOf(feature);
+    const index = state.features.indexOf(feature);
 
     if (index > -1) {
-      state.splice(index, 1);
+      state.features.splice(index, 1);
+    }
+  },
+
+  ADD_SMOOTHING_ID(state, id) {
+    state.smoothingIds.push(id);
+  },
+
+  REMOVE_SMOOTHING_ID(state, id) {
+    const index = state.smoothingIds.indexOf(id);
+
+    if (index > -1) {
+      state.smoothingIds.splice(index, 1);
     }
   }
 };

--- a/src/components/InputConfig.vue
+++ b/src/components/InputConfig.vue
@@ -3,18 +3,21 @@
     class="input-config"
     v-infoView="{ title: iVTitle, body: iVBody, id: 'Input Config Panel' }"
   >
-    <grid>
+    <grid columns="2">
       <c span="1..">{{ focusedInputTitle }}</c>
 
-      <c span="1..">
+      <c span="1">Audio Feature</c>
+      <c span="1">
         <AudioFeatures v-if="inputConfig" :input-id="inputConfig.id" />
       </c>
 
-      <c span="1..">
+      <c span="1">MIDI</c>
+      <c span="1">
         <MIDI v-if="inputConfig" :input-id="inputConfig.id" />
       </c>
 
-      <c span="1..">
+      <c span="1">Tween</c>
+      <c span="1">
         <Tween v-if="inputConfig" :input-id="inputConfig.id" />
       </c>
     </grid>

--- a/src/components/InputConfig.vue
+++ b/src/components/InputConfig.vue
@@ -3,24 +3,42 @@
     class="input-config"
     v-infoView="{ title: iVTitle, body: iVBody, id: 'Input Config Panel' }"
   >
-    <grid columns="2">
-      <c span="1..">{{ focusedInputTitle }}</c>
+    <div v-if="inputConfig">
+      <grid class="borders">
+        <c span="1.."
+          ><h3>{{ focusedInputTitle }}</h3></c
+        >
+        <c span="1..">
+          <grid columns="4">
+            <c span="1"><h4>Audio Feature</h4></c>
+            <c span="3">
+              <AudioFeatures :input-id="inputConfig.id" />
+            </c>
+          </grid>
+        </c>
 
-      <c span="1">Audio Feature</c>
-      <c span="1">
-        <AudioFeatures v-if="inputConfig" :input-id="inputConfig.id" />
-      </c>
+        <c span="1..">
+          <grid columns="4">
+            <c span="1"><h4>MIDI</h4></c>
+            <c span="3">
+              <MIDI :input-id="inputConfig.id" />
+            </c>
+          </grid>
+        </c>
 
-      <c span="1">MIDI</c>
-      <c span="1">
-        <MIDI v-if="inputConfig" :input-id="inputConfig.id" />
-      </c>
-
-      <c span="1">Tween</c>
-      <c span="1">
-        <Tween v-if="inputConfig" :input-id="inputConfig.id" />
-      </c>
-    </grid>
+        <c span="1..">
+          <grid columns="4">
+            <c span="1"><h4>Tween</h4></c>
+            <c span="3">
+              <Tween :input-id="inputConfig.id" />
+            </c>
+          </grid>
+        </c>
+      </grid>
+    </div>
+    <div v-else>
+      Select a Module control
+    </div>
   </div>
 </template>
 
@@ -70,5 +88,9 @@ export default {
 div.input-config {
   height: 100%;
   width: 100%;
+}
+
+grid.borders > c:not(:last-child):not(:first-child) {
+  border-bottom: 1px solid var(--foreground-color-2);
 }
 </style>

--- a/src/components/InputLinkComponents/AudioFeatures.vue
+++ b/src/components/InputLinkComponents/AudioFeatures.vue
@@ -13,20 +13,23 @@
     <c>
       <button @click="removeLink" :disabled="!hasLink">Remove link</button>
     </c>
-    <c span="2">
-      <label
-        >Use smoothing?<input type="checkbox" v-model="useSmoothing"
-      /></label>
-    </c>
-    <c span="2">
-      <label
-        >Smoothing<input
-          type="range"
-          min="0"
-          :max="MAX_SMOOTHING - SMOOTHING_STEP"
-          :step="SMOOTHING_STEP"
-          @input="smoothingInput"
-      /></label>
+    <c span="4" v-infoView="{ title: iVTitle, body: iVBody, id: iVID }">
+      <grid columns="2"
+        ><c>
+          <label
+            >Use smoothing?<input type="checkbox" v-model="useSmoothing"
+          /></label>
+        </c>
+        <c>
+          <label
+            >Smoothing<input
+              type="range"
+              min="0"
+              :max="MAX_SMOOTHING - SMOOTHING_STEP"
+              :step="SMOOTHING_STEP"
+              @input="smoothingInput"/></label
+        ></c>
+      </grid>
     </c>
   </grid>
 </template>
@@ -46,6 +49,11 @@ export default {
 
   data() {
     return {
+      iVTitle: "Audio Feature Smoothing",
+      iVBody:
+        "Turning on audio feature smoothing gives the audio feature a smoother decent to the set minimum value when linked to module properties. Smoothing captures the last peak value of the selected audio feature and attempts to slowly decrease the value back down to the minumum value. If the peak value is greater than the current captured peak the new peak will take priority.",
+      iVID: "Audio Feature Smoothing",
+
       features: [
         "rms",
         "zcr",


### PR DESCRIPTION
Adds a mechanism to generate smooth falling values for meyda's audio
features. Smoothing is not a moving average, just a linear decent to
zero each time the original signal is lower than the smoothed.

fixes #370

(moved from https://github.com/vcync/modv-3/pull/200)