### PR TITLE
fix(semantic-release): defines git plugin assets

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,4 +1,14 @@
 {
   "branches": ["main"],
-  "tagFormat": "${version}"
+  "tagFormat": "${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
+    ["@semantic-release/git", {
+      "assets": ["package.json"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }],
+    "@semantic-release/github"
+  ]
 }


### PR DESCRIPTION
makes sure updates package.json is comitted before a release/tag is created to allow
electron-builder and electron-updater to publish a new release

re: #399