### PR TITLE
fix(font-selection): adds font-list to externals list

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -45,7 +45,8 @@ module.exports = {
         "stream-to-blob",
         "grandiose",
         "npm",
-        "webpack-2"
+        "webpack-2",
+        "font-list"
       ],
 
       builderOptions: {


### PR DESCRIPTION
This tells the build process to use font-list as a node.js module rather than attempt to bundle it
in the renderer bundle

fixes #442