### PR TITLE
build(notarize): adds check for apple credentials

### DIFF
--- a/notarize.js
+++ b/notarize.js
@@ -3,7 +3,11 @@ const { notarize } = require("electron-notarize");
 
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
-  if (electronPlatformName !== "darwin") {
+  if (
+    electronPlatformName !== "darwin" ||
+    !process.env.APPLEID ||
+    !process.env.APPLEIDPASS
+  ) {
     return;
   }
 


### PR DESCRIPTION
Local builds will fail if the environment variables for notarization are not satisfied. Notarization
is not required when testing a build locally, so this allows local builds to complete without Apple
credentials