### PR TITLE
fix(input-config): adds clear action for focused input ids

### DIFF
--- a/src/application/worker/store/modules/inputs.js
+++ b/src/application/worker/store/modules/inputs.js
@@ -21,6 +21,10 @@ const actions = {
     commit("SET_FOCUSED_INPUT", { id, title, writeToSwap });
   },
 
+  clearFocusedInput({ commit }) {
+    commit("SET_FOCUSED_INPUT", { id: null, title: null });
+  },
+
   addInput({ commit }, { type, location, data, id = uuidv4(), writeToSwap }) {
     const input = { type, location, data, id };
     commit("ADD_INPUT", { input, writeToSwap });

--- a/src/components/ActiveModule.vue
+++ b/src/components/ActiveModule.vue
@@ -205,9 +205,11 @@ export default {
       return this.$modV.store.state.inputs.focusedInput.id === id;
     },
 
-    removeModule(e) {
+    async removeModule(e) {
       if (e.keyCode === 8 || e.keyCode === 46) {
         this.$store.commit("ui-modules/SET_FOCUSED", null);
+        await this.$modV.store.dispatch("inputs/clearFocusedInput");
+
         this.$emit("remove-module", this.id);
       }
     }


### PR DESCRIPTION
Adds a clear action to set the focused input id and title to null. Adds this to the activemodule.vue
remove function to clear the input config panel when a focused module is removed

closes #482