### PR TITLE
fix(group.vue): adds .self to keypress listener

### DIFF
--- a/src/components/Group.vue
+++ b/src/components/Group.vue
@@ -8,7 +8,7 @@
       focusElement: true
     }"
     tabindex="0"
-    @keydown="removeGroup"
+    @keydown.self="removeGroup"
   >
     <div
       class="group__controls"


### PR DESCRIPTION
Prevents listening for bubbled events

closes #488