### PR TITLE
feat(ui-focus): adds store module to track focused ui element

### DIFF
--- a/src/components/ActiveModule.vue
+++ b/src/components/ActiveModule.vue
@@ -3,7 +3,9 @@
     class="active-module"
     tabindex="0"
     @keydown="removeModule"
+    @focus="clickActiveModule"
     ref="activeModule"
+    :class="{ focused }"
   >
     <div class="active-module__title handle">
       {{ name }}
@@ -13,7 +15,7 @@
         <grid
           columns="6"
           @mousedown="
-            clickActiveModule(module && module.meta.enabledInputId, 'Enable')
+            focusInput(module && module.meta.enabledInputId, 'Enable')
           "
           :class="{
             'has-link': hasLink(module && module.meta.enabledInputId),
@@ -161,6 +163,14 @@ export default {
       }
 
       return this.module.meta.name;
+    },
+
+    focusedModule() {
+      return this.$store.state["focus"].type === "module";
+    },
+
+    focused() {
+      return this.focusedModule && this.id === this.$store.state["focus"].id;
     }
   },
 
@@ -191,9 +201,12 @@ export default {
       });
     },
 
-    clickActiveModule(inputId, title) {
-      this.focusInput(inputId, title);
-      this.$refs.activeModule.focus();
+    async clickActiveModule() {
+      await this.$store.dispatch("focus/setFocus", {
+        id: this.id,
+        type: "module"
+      });
+
       this.$store.commit("ui-modules/SET_FOCUSED", this.id);
     },
 
@@ -222,7 +235,8 @@ export default {
   font-size: 14px;
 }
 
-.active-module:focus {
+.active-module:focus,
+.active-module.focused {
   outline: #c4c4c4 2px solid;
 }
 

--- a/src/components/GalleryItem.vue
+++ b/src/components/GalleryItem.vue
@@ -122,7 +122,11 @@ export default {
     },
 
     async doubleClick() {
-      const groupId = this.$store.state["ui-groups"].focused;
+      if (this.$store.state.focus.type !== "group") {
+        return;
+      }
+
+      const groupId = this.$store.state.focus.id;
       if (!groupId) {
         return;
       }

--- a/src/components/Group.vue
+++ b/src/components/Group.vue
@@ -9,6 +9,9 @@
     }"
     tabindex="0"
     @keydown="removeGroup"
+    @focus.self="focus"
+    @mousedown.self="focus"
+    :class="{ focused }"
   >
     <div
       class="group__controls"
@@ -322,6 +325,10 @@ export default {
 
   created() {
     this.localName = this.name;
+
+    if (!this.focusedGroup) {
+      this.focus();
+    }
   },
 
   computed: {
@@ -346,6 +353,16 @@ export default {
           modules
         });
       }
+    },
+
+    focusedGroup() {
+      return this.$store.state["focus"].type === "group";
+    },
+
+    focused() {
+      return (
+        this.focusedGroup && this.groupId === this.$store.state["focus"].id
+      );
     },
 
     enabled: {
@@ -470,6 +487,15 @@ export default {
       return { moduleId, collection: "layer" };
     },
 
+    focus() {
+      if (!this.focused) {
+        this.$store.dispatch("focus/setFocus", {
+          id: this.groupId,
+          type: "group"
+        });
+      }
+    },
+
     removeModule(moduleId) {
       const { groupId } = this;
 
@@ -506,7 +532,7 @@ export default {
     },
 
     focusInput(id, title) {
-      this.$modV.store.dispatch("inputs/setFocusedInput", {
+      this.store.dispatch("inputs/setFocusedInput", {
         id,
         title: `${this.name}: ${title}`
       });
@@ -543,7 +569,8 @@ export default {
   margin-bottom: 8px;
 }
 
-.group:focus {
+.group:focus,
+.group.focused {
   outline: #c4c4c4 2px solid;
 }
 

--- a/src/ui-store/modules/focus.js
+++ b/src/ui-store/modules/focus.js
@@ -1,0 +1,32 @@
+const state = {
+  id: null,
+  type: null
+};
+
+const actions = {
+  setFocus({ commit }, args) {
+    if (!args.id) {
+      throw new Error("Missing ID");
+    }
+
+    if (!args.type) {
+      throw new Error("Missing type");
+    }
+
+    commit("SET_FOCUS", args);
+  }
+};
+
+const mutations = {
+  SET_FOCUS(state, { id, type }) {
+    state.id = id;
+    state.type = type;
+  }
+};
+
+export default {
+  namespaced: true,
+  state,
+  actions,
+  mutations
+};


### PR DESCRIPTION
To accommodate group deletion via keypress we require some place to track the currently focused UI item. 

This presents complications with double-clicking to add modules to a focused group, so this breaks the existing functionality slightly.

Groups are no longer infinitely focusable. If a module or other UI element becomes focused, the group will blur and double clicking a module in the gallery will not add the module to the group.

We may want to add the feature of "double clicking will add the module to the last selected group" instead, and show some other UI focus-like ring around the last focused group to indicate where the module will end-up.
Does this sound okay, @TimPietrusky ?

re #486