### PR TITLE
fix(preview.vue): passes Observer argument to resize function

### DIFF
--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -59,7 +59,7 @@ export default {
           return;
         }
 
-        this.resize();
+        this.resize(entries);
       });
     }).observe(container);
 


### PR DESCRIPTION
Passes the Resize Observer to the resize function

fixes #487