### PR TITLE
feat(midi): Support for NoteOn and CC buttons

### DIFF
--- a/src/application/setup-midi.js
+++ b/src/application/setup-midi.js
@@ -114,7 +114,6 @@ function handleInput(message) {
     }
 
     if (commitValue) {
-      console.log(_type, _data);
       store.commit("midi/WRITE_DATA", {
         id: `${id}-${name}-${manufacturer}`,
         type: _type,

--- a/src/application/worker/store/modules/midi.js
+++ b/src/application/worker/store/modules/midi.js
@@ -37,7 +37,8 @@ const mutations = {
       manufacturer,
       channelData: {},
       listenForInput: true,
-      listenForClock: false
+      listenForClock: false,
+      ccAsNoteOn: false
     });
   },
 

--- a/src/application/worker/store/modules/midi.js
+++ b/src/application/worker/store/modules/midi.js
@@ -60,7 +60,13 @@ const mutations = {
   },
 
   SET_STATE(state, newState) {
-    state = { ...newState };
+    const keys = Object.keys(newState);
+
+    for (let i = 0, len = keys.length; i < len; i++) {
+      const key = keys[i];
+
+      state[key] = newState[key];
+    }
   }
 };
 

--- a/src/application/worker/store/modules/midi.js
+++ b/src/application/worker/store/modules/midi.js
@@ -38,7 +38,8 @@ const mutations = {
       channelData: {},
       listenForInput: true,
       listenForClock: false,
-      ccAsNoteOn: false
+      ccLatch: false,
+      noteOnLatch: false
     });
   },
 

--- a/src/components/InputDeviceConfig/MIDI.vue
+++ b/src/components/InputDeviceConfig/MIDI.vue
@@ -11,15 +11,16 @@
   >
     <c span="1">MIDI Inputs</c>
     <c span="1..">
-      <grid columns="4">
+      <grid columns="5">
         <c>Name</c>
         <c>Input</c>
         <c>Clock</c>
-        <c>CC as NoteOn</c>
+        <c>CC Latch</c>
+        <c>NoteOn Latch</c>
       </grid>
     </c>
     <c span="1.." v-for="(device, deviceId) in devices" :key="deviceId">
-      <grid columns="4">
+      <grid columns="5">
         <c>{{ device.name }}</c>
         <c>
           <Button
@@ -40,9 +41,17 @@
         <c>
           <Button
             class="light"
-            @click="toggleCcAsNoteOn(deviceId, !device.ccAsNoteOn)"
+            @click="toggleCcLatch(deviceId, !device.ccLatch)"
           >
-            {{ device.ccAsNoteOn ? "On" : "Off" }}
+            {{ device.ccLatch ? "On" : "Off" }}
+          </Button>
+        </c>
+        <c>
+          <Button
+            class="light"
+            @click="toggleNoteOnLatch(deviceId, !device.noteOnLatch)"
+          >
+            {{ device.noteOnLatch ? "On" : "Off" }}
           </Button>
         </c>
       </grid>
@@ -83,10 +92,18 @@ export default {
       });
     },
 
-    toggleCcAsNoteOn(id, value) {
+    toggleCcLatch(id, value) {
       this.$modV.store.commit("midi/UPDATE_DEVICE", {
         id,
-        key: "ccAsNoteOn",
+        key: "ccLatch",
+        value
+      });
+    },
+
+    toggleNoteOnLatch(id, value) {
+      this.$modV.store.commit("midi/UPDATE_DEVICE", {
+        id,
+        key: "noteOnLatch",
         value
       });
     }

--- a/src/components/InputDeviceConfig/MIDI.vue
+++ b/src/components/InputDeviceConfig/MIDI.vue
@@ -15,6 +15,7 @@
         <c>Name</c>
         <c>Input</c>
         <c>Clock</c>
+        <c>CC as NoteOn</c>
       </grid>
     </c>
     <c span="1.." v-for="(device, deviceId) in devices" :key="deviceId">
@@ -34,6 +35,14 @@
             @click="toggleClock(deviceId, !device.listenForClock)"
           >
             {{ device.listenForClock ? "On" : "Off" }}
+          </Button>
+        </c>
+        <c>
+          <Button
+            class="light"
+            @click="toggleCcAsNoteOn(deviceId, !device.ccAsNoteOn)"
+          >
+            {{ device.ccAsNoteOn ? "On" : "Off" }}
           </Button>
         </c>
       </grid>
@@ -70,6 +79,14 @@ export default {
       this.$modV.store.commit("midi/UPDATE_DEVICE", {
         id,
         key: "listenForClock",
+        value
+      });
+    },
+
+    toggleCcAsNoteOn(id, value) {
+      this.$modV.store.commit("midi/UPDATE_DEVICE", {
+        id,
+        key: "ccAsNoteOn",
         value
       });
     }


### PR DESCRIPTION
fix #506

What is still missing is to light up the button and to loading "ccAsNoteOn" from the preset (as right now it's disabled after the preset is loaded. 