### PR TITLE
fix(grandiose): replaces __dirname path for .asar compatibility

### DIFF
--- a/src/application/worker/store/modules/ndi.js
+++ b/src/application/worker/store/modules/ndi.js
@@ -4,8 +4,10 @@ import uuidv4 from "uuid/v4";
 import Vue from "vue";
 import store from "../";
 
-// eslint-disable-next-line
+/* eslint-disable */
 __dirname = `${__dirname}/node_modules/grandiose`;
+__dirname = __dirname.replace("app.asar", "app.asar.unpacked");
+/* eslint-enable */
 
 const grandiose = require("grandiose");
 


### PR DESCRIPTION
Electron uses .asar files to compress resources, they get unpacked when the application is launched to a real directory. We need to update the path so Grandiose can resolve the correct files on the filesystem.

fix #553