### PR TITLE
fix(entitlements): adds disable-library-validation

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -10,5 +10,7 @@
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Adds entitlement to disable checking of loading unsigned 3rd-party library code. This allows the use
of some popular virtual webcams such as CamTwist, OBS Virtual Camera and Canon EOS Webcam Utility

fixes #570