### PR TITLE
chore(meyda): Use 5.2.0 instead of vcync/meyda

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lfo-for-modv": "0.0.1",
     "lodash.get": "^4.4.2",
     "mathjs": "^7.5.1",
-    "meyda": "vcync/meyda",
+    "meyda": "^5.2.0",
     "mkdirp": "^0.5.1",
     "npm": "6.14.6",
     "nwjs-menu-browser": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7533,14 +7533,15 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-meyda@vcync/meyda:
-  version "0.0.0-development"
-  resolved "https://codeload.github.com/vcync/meyda/tar.gz/54d52b16a644fe471b3e83ba237643d3b0b708bf"
+meyda@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/meyda/-/meyda-5.2.0.tgz#7c754e9b1827025a227b162e04a63e84bb2c9e6b"
+  integrity sha512-M9Z+LzYrZMvIN2Y7OdbHOuaCIAM+Jsqe9OH8Vq0zTZPhE3vB/3BmDNq4uJuVi4MM1nLb0iqJOntQBdGBmv3GWA==
   dependencies:
     dct "0.1.0"
     fftjs "0.0.4"
     node-getopt "^0.3.2"
-    wav "^1.0.0"
+    wav "^1.0.2"
 
 micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
@@ -12095,7 +12096,7 @@ watchpack@^1.3.1, watchpack@^1.6.1:
     chokidar "^3.4.0"
     watchpack-chokidar2 "^2.0.0"
 
-wav@^1.0.0:
+wav@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wav/-/wav-1.0.2.tgz#bdbf3fa0d9b4519e9dfd2f603299ead0a2f22060"
   integrity sha512-viHtz3cDd/Tcr/HbNqzQCofKdF6kWUymH9LGDdskfWFoIy/HJ+RTihgjEcHfnsy1PO4e9B+y4HwgTwMrByquhg==


### PR DESCRIPTION
We fixed a problem related to M1 and forked meyda, see https://github.com/meyda/meyda/pull/825

As this is resolved, we can use upstream meyda again! 