### PR TITLE
fix: fixes loading presets with textures referencing groups

### DIFF
--- a/src/application/worker/store/modules/dataTypes.js
+++ b/src/application/worker/store/modules/dataTypes.js
@@ -38,7 +38,7 @@ const state = {
         textureDefinition.id = id;
       }
 
-      if (type === "canvas") {
+      if (type === "canvas" || type == "group") {
         const { id } = options;
         textureDefinition.location = "outputs/auxillaryCanvas";
         textureDefinition.id = id;

--- a/src/application/worker/store/modules/groups.js
+++ b/src/application/worker/store/modules/groups.js
@@ -109,9 +109,12 @@ const actions = {
       return writeTo.groups[existingGroupIndex];
     }
 
+    const id = args.id || uuidv4();
+
     const group = {
       ...args,
       name,
+      id,
       clearing: args.clearing || false,
       enabled: args.enabled || false,
       hidden: args.hidden || false,
@@ -121,9 +124,9 @@ const actions = {
       compositeOperation: args.compositeOperation || "normal",
       context: await store.dispatch("outputs/getAuxillaryOutput", {
         name,
-        group: "group"
-      }),
-      id: args.id || uuidv4()
+        group: "group",
+        id
+      })
     };
 
     const alphaInputBind = await store.dispatch("inputs/addInput", {

--- a/src/application/worker/store/modules/outputs.js
+++ b/src/application/worker/store/modules/outputs.js
@@ -53,6 +53,7 @@ const actions = {
       type = "2d",
       options = {},
       group = "",
+      id = "",
       reactToResize = true,
       width = state.main ? state.main.canvas.width : 300,
       height = state.main ? state.main.canvas.height : 300
@@ -70,14 +71,15 @@ const actions = {
       name,
       context,
       reactToResize,
-      group
+      group,
+      id
     });
 
     return outputContext;
   },
 
   addAuxillaryOutput({ commit }, outputContext) {
-    outputContext.id = uuidv4();
+    outputContext.id = outputContext.id || uuidv4();
     commit("ADD_AUXILLARY", outputContext);
     return outputContext;
   },

--- a/src/components/Controls/TextureControl.vue
+++ b/src/components/Controls/TextureControl.vue
@@ -11,7 +11,7 @@
     </select>
 
     <div v-if="type === 'group'">
-      <select v-model="modelCanvasId" @change="setTexture('canvas')">
+      <select v-model="modelCanvasId" @change="setTexture('group')">
         <option v-for="group in groupOutputs" :value="group.id" :key="group.id">
           {{ group.name }}
         </option>
@@ -68,7 +68,8 @@ export default {
       this.value.type && this.value.type.length
         ? this.value.type
         : this.textureTypes[0];
-    this.modelImagePath = this.value.options.path;
+    this.modelImagePath = this.value.options.path || "";
+    this.modelCanvasId = this.value.options.id || "";
   },
 
   computed: {
@@ -117,7 +118,7 @@ export default {
         textureDefinition.options.path = this.modelImagePath;
       }
 
-      if (type === "canvas") {
+      if (type === "canvas" || type === "group") {
         if (!this.modelCanvasId) {
           return;
         }


### PR DESCRIPTION
Updates groups and outputContexts to share the same ID on creation. This fixes bad references when loading presets with texture types saved with a group reference

fixes #590