### PR TITLE
fix: slow post message

### DIFF
--- a/src/application/index.js
+++ b/src/application/index.js
@@ -83,7 +83,14 @@ export default class ModV {
       }
       // }
 
-      store.commit(type, payload);
+      if (type === "commitQueue") {
+        for (let i = 0; i < payload.length; i++) {
+          const commit = payload[i];
+          store.commit(commit.type, commit.payload);
+        }
+      } else {
+        store.commit(type, payload);
+      }
     });
 
     const that = this;
@@ -92,10 +99,9 @@ export default class ModV {
       state: store.state,
       getters: store.getters,
 
-      async commit(...args) {
-        return await that.$asyncWorker.postMessage(
+      commit(...args) {
+        return that.$worker.postMessage(
           {
-            __async: true,
             type: "commit",
             identifier: args[0],
             payload: args[1]

--- a/src/application/index.js
+++ b/src/application/index.js
@@ -59,29 +59,28 @@ export default class ModV {
     });
 
     this.$worker.addEventListener("message", e => {
-      if (e.data.type === "tick" && this.ready) {
-        this.tick(e.data.payload);
-        return;
-      }
-
       const message = e.data;
       const { type } = message;
-
-      if (Array.isArray(message)) {
-        return;
-      }
-      const payload = e.data.payload ? JSON.parse(e.data.payload) : undefined;
 
       // if (
       //   type !== "metrics/SET_FPS_MEASURE" &&
       //   type !== "modules/UPDATE_ACTIVE_MODULE_PROP" &&
       //   type !== "beats/SET_BPM" &&
-      //   type !== "beats/SET_KICK"
+      //   type !== "beats/SET_KICK" &&
+      //   type !== "tick"
       // ) {
-      if (this.debug) {
-        console.log(`⚙️%c ${type}`, "color: red", payload);
-      }
+      //   console.log(`⚙️%c ${type}`, "color: red");
       // }
+
+      if (e.data.type === "tick" && this.ready) {
+        this.tick(e.data.payload);
+        return;
+      }
+
+      if (Array.isArray(message)) {
+        return;
+      }
+      const payload = e.data.payload ? JSON.parse(e.data.payload) : undefined;
 
       if (type === "commitQueue") {
         for (let i = 0; i < payload.length; i++) {
@@ -110,8 +109,8 @@ export default class ModV {
         );
       },
 
-      async dispatch(...args) {
-        return await that.$asyncWorker.postMessage(
+      dispatch(...args) {
+        return that.$asyncWorker.postMessage(
           {
             __async: true,
             type: "dispatch",

--- a/src/application/worker/index.worker.js
+++ b/src/application/worker/index.worker.js
@@ -100,12 +100,6 @@ async function start() {
   });
 
   function sendCommitQueue() {
-    if (commitQueue.length === 0) {
-      return;
-    } else {
-      console.log("commitQueueLength", commitQueue.length);
-    }
-
     const commits = JSON.stringify(commitQueue);
     commitQueue.splice(0, commitQueue.length);
 
@@ -363,19 +357,10 @@ async function start() {
         return JSON.stringify(preset);
       }
 
-      if (identifier === "groups/REPLACE_GROUP_MODULES") {
-        console.log("message recieved");
-      }
-
       /**
        * @todo Don't JSON parse and stringify
        */
       const value = await store[type](identifier, payload);
-
-      if (identifier === "groups/REPLACE_GROUP_MODULES") {
-        console.log("processed store shit");
-        debugger;
-      }
 
       if (value) {
         return JSON.parse(JSON.stringify(value));

--- a/src/application/worker/index.worker.js
+++ b/src/application/worker/index.worker.js
@@ -65,9 +65,9 @@ async function start() {
 
       const { type, location, data } = bind;
 
-      const { type: linkType, location: linkLocation, match } = link;
+      const { location: linkLocation, match } = link;
 
-      if (linkType !== "mutation" || match.type !== mutationType) {
+      if (match.type !== mutationType) {
         continue;
       }
 

--- a/src/application/worker/index.worker.js
+++ b/src/application/worker/index.worker.js
@@ -9,6 +9,7 @@ async function start() {
   const store = require("./store").default;
   const loop = require("./loop").default;
   const grabCanvasPlugin = require("../plugins/grab-canvas").default;
+  const get = require("lodash.get");
 
   const { tick: frameTick } = require("./frame-counter");
   const { getFeatures, setFeatures } = require("./audio-features");
@@ -19,27 +20,80 @@ async function start() {
   const commitQueue = [];
 
   store.subscribe(mutation => {
-    const { type, payload } = mutation;
+    const { type: mutationType, payload: mutationPayload } = mutation;
 
-    if (type === "beats/SET_BPM" || type === "fps/SET_FPS") {
-      store.dispatch("tweens/updateBpm", { bpm: payload.bpm });
+    if (mutationType === "beats/SET_BPM" || mutationType === "fps/SET_FPS") {
+      store.dispatch("tweens/updateBpm", { bpm: mutationPayload.bpm });
     }
 
-    if (type === "beats/SET_KICK" && payload.kick === lastKick) {
+    if (
+      mutationType === "beats/SET_KICK" &&
+      mutationPayload.kick === lastKick
+    ) {
       return;
-    } else if (type === "beats/SET_KICK" && payload.kick !== lastKick) {
-      lastKick = payload.kick;
+    } else if (
+      mutationType === "beats/SET_KICK" &&
+      mutationPayload.kick !== lastKick
+    ) {
+      lastKick = mutationPayload.kick;
     }
 
-    if (type === "fps/SET_FPS") {
+    if (mutationType === "fps/SET_FPS") {
       interval = store.getters["fps/interval"];
     }
 
     if (
-      type === "modules/UPDATE_ACTIVE_MODULE" &&
-      (payload.key !== "props" || payload.key !== "meta")
+      mutationType === "modules/UPDATE_ACTIVE_MODULE" &&
+      (mutationPayload.key !== "props" || mutationPayload.key !== "meta")
     ) {
       return;
+    }
+
+    const {
+      inputs: { inputs, inputLinks }
+    } = store.state;
+
+    // Update mutation type Input Links
+    const mutationTypeInputLinks = Object.values(inputLinks).filter(
+      link => link.type === "mutation"
+    );
+    const inputLinksLength = mutationTypeInputLinks.length;
+    for (let i = 0; i < inputLinksLength; ++i) {
+      const link = mutationTypeInputLinks[i];
+      const inputId = link.id;
+      const bind = inputs[inputId];
+
+      const { type, location, data } = bind;
+
+      const { type: linkType, location: linkLocation, match } = link;
+
+      if (linkType !== "mutation" || match.type !== mutationType) {
+        continue;
+      }
+
+      let payloadMatches = false;
+
+      if (match.payload) {
+        const matchPayloadKeys = Object.keys(match.payload);
+        payloadMatches = matchPayloadKeys.every(key => {
+          const value = match.payload[key];
+          return value === mutationPayload[key];
+        });
+      } else {
+        payloadMatches = true;
+      }
+
+      if (!payloadMatches) {
+        continue;
+      }
+
+      const value = get(store.state, linkLocation);
+
+      if (type === "action") {
+        store.dispatch(location, { ...data, data: value });
+      } else if (type === "commit") {
+        store.commit(location, { ...data, data: value });
+      }
     }
 
     commitQueue.push(mutation);
@@ -48,6 +102,8 @@ async function start() {
   function sendCommitQueue() {
     if (commitQueue.length === 0) {
       return;
+    } else {
+      console.log("commitQueueLength", commitQueue.length);
     }
 
     const commits = JSON.stringify(commitQueue);
@@ -307,10 +363,19 @@ async function start() {
         return JSON.stringify(preset);
       }
 
+      if (identifier === "groups/REPLACE_GROUP_MODULES") {
+        console.log("message recieved");
+      }
+
       /**
        * @todo Don't JSON parse and stringify
        */
       const value = await store[type](identifier, payload);
+
+      if (identifier === "groups/REPLACE_GROUP_MODULES") {
+        console.log("processed store shit");
+        debugger;
+      }
 
       if (value) {
         return JSON.parse(JSON.stringify(value));

--- a/src/application/worker/loop.js
+++ b/src/application/worker/loop.js
@@ -69,8 +69,21 @@ function loop(delta, features, fftOutput) {
       location: linkLocation,
       args: linkArguments,
       min,
-      max
+      max,
+      source
     } = link;
+
+    const moduleId = store.state.inputs.inputs[inputId].data.moduleId;
+
+    if (
+      linkType === "mutation" ||
+      (source === "meyda" &&
+        moduleId &&
+        !store.state.modules.active[moduleId].meta.enabled)
+    ) {
+      continue;
+    }
+
     let value;
 
     if (linkType === "getter" && linkArguments) {

--- a/src/application/worker/loop.js
+++ b/src/application/worker/loop.js
@@ -75,6 +75,9 @@ function loop(delta, features, fftOutput) {
 
     const moduleId = store.state.inputs.inputs[inputId].data.moduleId;
 
+    // check if the module is enabled for meyda sources, and if it is not, skip it
+    // mutation linkTypes are also skipped as they're handled in index.worker.js in
+    // the store commit subscription
     if (
       linkType === "mutation" ||
       (source === "meyda" &&

--- a/src/application/worker/store/modules/inputs.js
+++ b/src/application/worker/store/modules/inputs.js
@@ -41,6 +41,7 @@ const actions = {
       min = 0,
       max = 1,
       source,
+      match,
       writeToSwap
     }
   ) {
@@ -52,7 +53,16 @@ const actions = {
       return false;
     }
 
-    const inputLink = { id: inputId, location, type, args, min, max, source };
+    const inputLink = {
+      id: inputId,
+      location,
+      type,
+      args,
+      min,
+      max,
+      source,
+      match
+    };
     if (!writeTo.inputs[inputId]) {
       console.warn(
         "Did not create inputLink. Could not find input with id",

--- a/src/application/worker/store/modules/inputs.js
+++ b/src/application/worker/store/modules/inputs.js
@@ -1,7 +1,81 @@
 import Vue from "vue";
-
 import uuidv4 from "uuid/v4";
 import SWAP from "./common/swap";
+
+/**
+ * InputLinkType enum string values.
+ * @enum {String}
+ */
+// eslint-disable-next-line
+const InputLinkType = {
+  getter: "getter",
+  mutation: "mutation",
+  state: "state"
+};
+
+/**
+ * @typedef {Object} InputLink
+ *
+ * @property {String}  inputId             The ID of the @Input to link to
+ *
+ * @property {InputLinkType}  type         The type of the @InputLink
+ *
+ * @property {String}  source              Identifies what created and/or manages this input link
+ *
+ * @property {Number}  [min]               Minimum expected value, will scale the incoming value to
+ *                                         the input's min/max if min and max are set
+ *
+ * @property {Number}  [max]               Maximum expected value, will scale the incoming value to
+ *                                         the input's min/max if min and max are set
+ */
+
+/**
+ * @typedef {Object} InputLinkGetterType
+ *
+ * @property {String} location             location of the getter in the store, e.g. meyda/getFeature
+ *
+ * @property {Array}  [args]               arguments for a getter that is a function, e.g. ["energy"]
+ *
+ *
+ * ⚠️ updates every frame
+ * Reads a getter in the store, possibly with arguments, defined in ?args, and applies that to the
+ * input link defined with inputId
+ * @typedef {InputLink & InputLinkGetterType} InputLinkGetter
+ */
+
+/**
+ * @typedef {Object} InputLinkMutationType
+ *
+ * @property {String} location             location of the value to read in the store, e.g.
+ *                                         midi.devices[1].channelData[1][144]
+ *
+ * @property {Object} match                parameters of the mutation to match
+ *
+ * @property {String} match.type           Mutation type from the store, e.g. midi/WRITE_DATA
+ *
+ * @property {String} [match.payload]      Key-value pairs to match in the mutation payload, e.g.
+ *                                         {
+                                             id: `${id}-${name}-${manufacturer}`,
+                                             channel: 1,
+                                             type: 144,
+                                           }
+ *
+ * Waits for a mutation type, defined with match.type, possibly checks the mutation payload for
+ * specific unique parameters, defined on match.?payload, and applies a store value, specified
+ * with location, to the input link defined with inputId
+ * @typedef {InputLink & InputLinkMutationType} InputLinkMutation
+ */
+
+/**
+ * @typedef {Object} InputLinkStateType
+ *
+ * @property {String} location             location of the getter in the store, e.g.
+ *                                         midi.devices[1].channelData[1][144]
+ *
+ * ⚠️ updates every frame
+ * Reads a location in the store and applies that to the input link defined with inputId
+ * @typedef {InputLink & InputLinkStateType} InputLinkState
+ */
 
 function getDefaultState() {
   return {

--- a/src/components/InputLinkComponents/AudioFeatures.vue
+++ b/src/components/InputLinkComponents/AudioFeatures.vue
@@ -122,8 +122,11 @@ export default {
       if (this.feature === "kick") {
         this.$modV.store.dispatch("inputs/createInputLink", {
           inputId: this.inputId,
-          type: "state",
+          type: "mutation",
           location: "beats.kick",
+          match: {
+            type: "beats/SET_KICK"
+          },
           source: "meyda",
           args: [this.feature]
         });

--- a/src/components/InputLinkComponents/MIDI.vue
+++ b/src/components/InputLinkComponents/MIDI.vue
@@ -56,9 +56,17 @@ export default {
 
       this.hasLink = await this.$modV.store.dispatch("inputs/createInputLink", {
         inputId: this.inputId,
-        type: "state",
+        type: "mutation",
         source: "midi",
         location: `midi.devices['${id}-${name}-${manufacturer}'].channelData['${channel}']['${type}']`,
+        match: {
+          type: "midi/WRITE_DATA",
+          payload: {
+            id: `${id}-${name}-${manufacturer}`,
+            channel,
+            type
+          }
+        },
         min: 0,
         max: 1
       });


### PR DESCRIPTION
Limits meyda source input links for performance boost.
Adds new input link type "mutation" to further increase overall performance.

Adds a queue for syncing commits between the worker and renderer threads - sending lots of messages via postMessage is synchronous, it's better to send fewer messages with more content than lots of messages. we're talking around 40+ messages per 16ms here, so combining all these updates and syncing once per frame tick should help.