### PR TITLE
perf(module-inspector): changes v-for key from id to index

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,8 +26,8 @@
                 <!-- hack around dynamic components not working correctly. CSS below hides tabs with the title "hidden" -->
               </gl-component>
               <gl-component
-                v-for="module in focusedModules"
-                :key="module.$id"
+                v-for="(module, i) in focusedModules"
+                :key="i"
                 :title="`${module.meta.name} properties`"
                 :closable="false"
                 ref="moduleInspector"


### PR DESCRIPTION
This improves the performance of the module inspector when changing focused active modules.

Using the index instead of the ID forces Golden Layout to repaint less as the gl-component isn't recreated each time. We don't really care if it isn't recreated in this case so it's okay to use index over ID.

I've attached the preset and chrome performance profiles for comparison if this improvement can't be seen on a higher-end machine. Tested this on an older laptop.

[module-inspector-performance.zip](https://github.com/vcync/modV/files/7049695/module-inspector-performance.zip)
