### PR TITLE
fix(groups): fixes default value for groups inheritFrom

### DIFF
--- a/src/application/worker/store/modules/groups.js
+++ b/src/application/worker/store/modules/groups.js
@@ -120,7 +120,7 @@ const actions = {
       hidden: args.hidden || false,
       modules: args.modules || [],
       inherit,
-      inheritFrom: -1,
+      inheritFrom: args.inheritFrom || -1,
       alpha: args.alpha || 1,
       compositeOperation: args.compositeOperation || "normal",
       context: await store.dispatch("outputs/getAuxillaryOutput", {


### PR DESCRIPTION
Makes sure the arguments are given priority over default values

fixes #627