### PR TITLE
fix(tooltip): fixes position of tooltip on windows

### DIFF
--- a/src/components/directives/ValueTooltip.js
+++ b/src/components/directives/ValueTooltip.js
@@ -83,7 +83,9 @@ function mouseUp() {
 }
 
 function mouseMove(e) {
-  setTooltipPosition(e);
+  if (!document.pointerLockElement) {
+    setTooltipPosition(e);
+  }
   setPreValue();
 }
 


### PR DESCRIPTION
When the pointer is locked, Chromium on Windows reports the cursor position as centre to the screen.
This adds a check to the tooltip directive to not reposition the tooltip if the pointer is locked.