### PR TITLE
fix(loop): adds context to update method

### DIFF
--- a/src/application/worker/loop.js
+++ b/src/application/worker/loop.js
@@ -222,6 +222,7 @@ function loop(delta, features, fftOutput) {
           data: { ...data },
           // canvas: drawTo.canvas,
           canvas,
+          context: drawTo,
           delta
         });
 


### PR DESCRIPTION
Modules should have access to the canvas context in the update method. This change fixes this.