### PR TITLE
fix(inputs): adds clean-up of inputs when modules or groups are removed

### DIFF
--- a/src/application/worker/store/modules/groups.js
+++ b/src/application/worker/store/modules/groups.js
@@ -213,6 +213,12 @@ const actions = {
       });
     }
 
+    for (let i = 0; i < group.modules.length; i += 1) {
+      const moduleId = group.modules[i];
+
+      await store.dispatch("modules/removeActiveModule", { moduleId });
+    }
+
     commit("REMOVE_GROUP", { id: groupId, writeToSwap });
   },
 

--- a/src/application/worker/store/modules/groups.js
+++ b/src/application/worker/store/modules/groups.js
@@ -193,6 +193,29 @@ const actions = {
     return group;
   },
 
+  async removeGroup({ commit }, { groupId, writeToSwap }) {
+    const group = state.groups.find(group => group.id === groupId);
+
+    const inputIds = [
+      group.alphaInputId,
+      group.enabledInputId,
+      group.clearingInputId,
+      group.inheritInputId,
+      group.compositeOperationInputId,
+      group.pipelineInputId
+    ];
+
+    for (let i = 0; i < inputIds.length; i += 1) {
+      const inputId = inputIds[i];
+
+      await store.dispatch("inputs/removeInput", {
+        inputId
+      });
+    }
+
+    commit("REMOVE_GROUP", { id: groupId, writeToSwap });
+  },
+
   orderByIds({ commit }, { ids }) {
     const newGroups = ids.map(id => {
       return state.groups.find(group => group.id === id);

--- a/src/application/worker/store/modules/inputs.js
+++ b/src/application/worker/store/modules/inputs.js
@@ -105,6 +105,22 @@ const actions = {
     return input;
   },
 
+  removeInput({ commit }, { inputId, writeToSwap }) {
+    const writeTo = writeToSwap ? swap : state;
+
+    if (!writeTo.inputs[inputId]) {
+      console.warn(
+        "Did not remove input. Could not find input with id",
+        inputId
+      );
+
+      return false;
+    }
+
+    commit("REMOVE_INPUT", { inputId, writeToSwap });
+    return true;
+  },
+
   createInputLink(
     { commit },
     {
@@ -209,6 +225,11 @@ const mutations = {
   ADD_INPUT(state, { input, writeToSwap }) {
     const writeTo = writeToSwap ? swap : state;
     writeTo.inputs[input.id] = input;
+  },
+
+  REMOVE_INPUT(state, { inputId, writeToSwap }) {
+    const writeTo = writeToSwap ? swap : state;
+    Vue.delete(writeTo.inputs, inputId);
   },
 
   ADD_INPUT_LINK(state, { inputLink, writeToSwap }) {

--- a/src/application/worker/store/modules/modules.js
+++ b/src/application/worker/store/modules/modules.js
@@ -507,6 +507,10 @@ const actions = {
         inputId,
         writeToSwap
       });
+
+      await store.dispatch("inputs/removeInput", {
+        inputId
+      });
     }
 
     commit("REMOVE_ACTIVE_MODULE", { moduleId, writeToSwap });

--- a/src/components/Group.vue
+++ b/src/components/Group.vue
@@ -69,11 +69,12 @@
             }"
           >
             <c span="2">Clearing</c>
-            <c span="4"
-              ><Checkbox
+            <c span="4">
+              <Checkbox
                 v-model="clearing"
                 :class="{ light: isFocused(group.clearingInputId) }"
-            /></c>
+              />
+            </c>
           </grid>
         </c>
 
@@ -87,11 +88,12 @@
             }"
           >
             <c span="2">Pipeline</c>
-            <c span="4"
-              ><Checkbox
+            <c span="4">
+              <Checkbox
                 v-model="pipeline"
                 :class="{ light: isFocused(group.pipelineInputId) }"
-            /></c>
+              />
+            </c>
           </grid>
         </c>
 
@@ -158,7 +160,7 @@
               </Select>
             </c>
           </grid>
-        </c> -->
+        </c>-->
       </grid>
     </div>
     <div class="group__left">
@@ -504,7 +506,9 @@ export default {
 
     removeGroup(e) {
       if (e.keyCode === 8 || e.keyCode === 46) {
-        this.$modV.store.commit("groups/REMOVE_GROUP", { id: this.groupId });
+        this.$modV.store.dispatch("groups/removeGroup", {
+          groupId: this.groupId
+        });
       }
     }
   },


### PR DESCRIPTION
Cleans up unneeded inputs, which in-turn will create cleaner presets.

<img width="1438" alt="Screenshot 2021-11-16 at 15 29 23" src="https://user-images.githubusercontent.com/554219/142053219-eee8fc78-d4ca-46e6-8702-b80e98938a57.png">
