### PR TITLE
fix(inputlinks): fixes mutation type inputlinks

### DIFF
--- a/src/application/worker/loop.js
+++ b/src/application/worker/loop.js
@@ -86,11 +86,12 @@ function loop(delta, features, fftOutput) {
     // mutation linkTypes are also skipped as they're handled in index.worker.js in
     // the store commit subscription
     if (
-      moduleId &&
-      (linkType === "mutation" ||
-        (source === "meyda" &&
-          moduleId &&
-          !store.state.modules.active[moduleId].meta.enabled))
+      (moduleId &&
+        (linkType === "mutation" ||
+          (source === "meyda" &&
+            moduleId &&
+            !store.state.modules.active[moduleId].meta.enabled))) ||
+      linkType === "mutation"
     ) {
       continue;
     }


### PR DESCRIPTION
prevents the inputlink handler in the main loop from writing any value to "mutation" type inputlinks
as they should be exclusively handled in the store mutation subscription