### PR TITLE
fix(renderers): implement new methods to handle updating and resizing modules

### DIFF
--- a/src/application/renderers/2d.js
+++ b/src/application/renderers/2d.js
@@ -65,9 +65,35 @@ function render({
   context.drawImage(twoDCanvas, 0, 0, canvas.width, canvas.height);
 }
 
+/**
+ * Called each frame to update the Module
+ */
+function updateModule({
+  moduleDefinition,
+  props,
+  data,
+  canvas,
+  context,
+  delta
+}) {
+  const { data: dataUpdated } = moduleDefinition.update({
+    props,
+    data,
+    canvas,
+    context,
+    delta
+  });
+
+  return dataUpdated ?? data;
+}
+
+function resizeModule({ moduleDefinition, canvas, data, props }) {
+  return moduleDefinition.resize({ canvas, data, props });
+}
+
 function resize({ width, height }) {
   twoDCanvas.width = width;
   twoDCanvas.height = height;
 }
 
-export default { render, resize };
+export default { render, resize, updateModule, resizeModule };

--- a/src/application/renderers/isf.js
+++ b/src/application/renderers/isf.js
@@ -60,6 +60,25 @@ function render({ module, canvas, context, pipeline, props }) {
   context.drawImage(isfCanvas, 0, 0, canvas.width, canvas.height);
 }
 
+/**
+ * Called each frame to update the Module
+ */
+function updateModule({ module, props, data, canvas, context, delta }) {
+  const { data: dataUpdated } = module.update({
+    props,
+    data,
+    canvas,
+    context,
+    delta
+  });
+
+  return dataUpdated ?? data;
+}
+
+function resizeModule({ moduleDefinition, canvas, data, props }) {
+  return moduleDefinition.resize({ canvas, data, props });
+}
+
 async function setupModule(module) {
   let fragmentShader = module.fragmentShader;
   let vertexShader = module.vertexShader;
@@ -176,5 +195,7 @@ async function setupModule(module) {
 export default {
   setupModule,
   render,
+  updateModule,
+  resizeModule,
   resize
 };

--- a/src/application/renderers/isf.js
+++ b/src/application/renderers/isf.js
@@ -79,9 +79,9 @@ function resizeModule({ moduleDefinition, canvas, data, props }) {
   return moduleDefinition.resize({ canvas, data, props });
 }
 
-async function setupModule(module) {
-  let fragmentShader = module.fragmentShader;
-  let vertexShader = module.vertexShader;
+async function setupModule(moduleDefinition) {
+  let fragmentShader = moduleDefinition.fragmentShader;
+  let vertexShader = moduleDefinition.vertexShader;
 
   const parser = new ISFParser();
   parser.parse(fragmentShader, vertexShader);
@@ -96,10 +96,10 @@ async function setupModule(module) {
     }
   }
 
-  module.meta.isfVersion = parser.isfVersion;
-  module.meta.author = parser.metadata.CREDIT;
-  module.meta.description = parser.metadata.DESCRIPTION;
-  module.meta.version = parser.metadata.VSN;
+  moduleDefinition.meta.isfVersion = parser.isfVersion;
+  moduleDefinition.meta.author = parser.metadata.CREDIT;
+  moduleDefinition.meta.description = parser.metadata.DESCRIPTION;
+  moduleDefinition.meta.version = parser.metadata.VSN;
 
   const renderer = new ISFRenderer(isfContext);
   renderer.loadSource(fragmentShader, vertexShader);
@@ -109,11 +109,11 @@ async function setupModule(module) {
   }
 
   function addProp(name, prop) {
-    if (!module.props) {
-      module.props = {};
+    if (!moduleDefinition.props) {
+      moduleDefinition.props = {};
     }
 
-    module.props[name] = prop;
+    moduleDefinition.props[name] = prop;
   }
 
   const moduleInputs = parser.inputs;
@@ -174,7 +174,7 @@ async function setupModule(module) {
         break;
 
       case "image":
-        module.meta.previewWithOutput = true;
+        moduleDefinition.meta.previewWithOutput = true;
 
         addProp(input.NAME, {
           type: "texture",
@@ -185,11 +185,11 @@ async function setupModule(module) {
     }
   }
 
-  renderers[module.meta.name] = renderer;
-  inputs[module.meta.name] = moduleInputs;
-  module.draw = render;
+  renderers[moduleDefinition.meta.name] = renderer;
+  inputs[moduleDefinition.meta.name] = moduleInputs;
+  moduleDefinition.draw = render;
 
-  return module;
+  return moduleDefinition;
 }
 
 export default {

--- a/src/application/renderers/shader/index.js
+++ b/src/application/renderers/shader/index.js
@@ -142,7 +142,6 @@ async function setupModule(Module) {
   }
 }
 
-
 function render({ module, props, canvas, context, pipeline, kick, fftCanvas }) {
   resize({ width: canvas.width, height: canvas.height });
 
@@ -214,4 +213,19 @@ function render({ module, props, canvas, context, pipeline, kick, fftCanvas }) {
   context.drawImage(shaderCanvas, 0, 0, canvas.width, canvas.height);
 }
 
-export { setupModule, render, resize };
+/**
+ * Called each frame to update the Module
+ */
+function updateModule({ module, props, data, canvas, context, delta }) {
+  const { data: dataUpdated } = module.update({
+    props,
+    data,
+    canvas,
+    context,
+    delta
+  });
+
+  return dataUpdated ?? data;
+}
+
+export { setupModule, render, resize, updateModule };

--- a/src/application/renderers/shader/index.js
+++ b/src/application/renderers/shader/index.js
@@ -74,10 +74,10 @@ function generateUniforms(canvasTexture, uniforms, kick = false) {
   return { ...uniforms, ...defaults };
 }
 
-function makeProgram(Module) {
+function makeProgram(moduleDefinition) {
   return new Promise(resolve => {
-    let vert = Module.vertexShader;
-    let frag = Module.fragmentShader;
+    let vert = moduleDefinition.vertexShader;
+    let frag = moduleDefinition.fragmentShader;
 
     if (!vert) {
       vert = defaultShader.v;
@@ -101,17 +101,17 @@ function makeProgram(Module) {
 
     const shaderUniforms = {};
 
-    if (Module.props) {
-      const modulePropsKeys = Object.keys(Module.props);
+    if (moduleDefinition.props) {
+      const modulePropsKeys = Object.keys(moduleDefinition.props);
       const modulePropsKeysLength = modulePropsKeys.length;
 
       for (let i = 0; i < modulePropsKeysLength; i++) {
         const key = modulePropsKeys[i];
 
-        if (Module.props[key].type === "texture") {
-          shaderUniforms[key] = Module.props[key].value;
+        if (moduleDefinition.props[key].type === "texture") {
+          shaderUniforms[key] = moduleDefinition.props[key].value;
         } else {
-          shaderUniforms[key] = Module.props[key];
+          shaderUniforms[key] = moduleDefinition.props[key];
         }
       }
     }
@@ -128,15 +128,15 @@ function makeProgram(Module) {
       uniforms
     };
 
-    commands[Module.meta.name] = command;
+    commands[moduleDefinition.meta.name] = command;
 
-    resolve(Module);
+    resolve(moduleDefinition);
   });
 }
 
-async function setupModule(Module) {
+async function setupModule(moduleDefinition) {
   try {
-    return await makeProgram(Module);
+    return await makeProgram(moduleDefinition);
   } catch (e) {
     throw new Error(e);
   }

--- a/src/application/renderers/three.js
+++ b/src/application/renderers/three.js
@@ -70,9 +70,9 @@ function render({
   inputTexture.image = inputTextureCanvas.transferToImageBitmap();
   inputTexture.needsUpdate = true;
 
-  const { scene, camera } = threeModuleData[module.$id];
+  const { scene } = threeModuleData[module.meta.name];
 
-  module.draw({
+  const { camera } = module.draw({
     THREE,
     inputTexture,
     canvas,
@@ -83,7 +83,7 @@ function render({
     bpm,
     kick,
     props,
-    data: { ...data, scene, camera },
+    data: { ...data, scene },
     fftCanvas
   });
 
@@ -107,13 +107,14 @@ async function setupModule(module) {
     height: renderer.domElement.height
   });
 
-  threeModuleData[module.$id] = {
-    scene: moduleData.scene,
-    camera: moduleData.camera
+  // We have to use the name for now, as module.$id is not defined yet.
+  // This gives us the limitation that we can't have multiple instances of the
+  // same three-module in modV as they would share the same scene
+  threeModuleData[module.meta.name] = {
+    scene: moduleData.scene
   };
 
   delete moduleData.scene;
-  delete moduleData.camera;
 
   module.data = moduleData;
 
@@ -121,15 +122,15 @@ async function setupModule(module) {
 }
 
 function removeModule(module) {
-  delete threeModuleData[module.$id];
+  delete threeModuleData[module.meta.name];
 }
 
 function createPresetData(module) {
-  return threeModuleData[module.$id];
+  return threeModuleData[module.meta.name];
 }
 
 function loadPresetData(module, data) {
-  threeModuleData[module.$id] = data;
+  threeModuleData[module.meta.name] = data;
 }
 
 function resize({ width, height }) {

--- a/src/application/renderers/three.js
+++ b/src/application/renderers/three.js
@@ -85,6 +85,7 @@ function render({
     props,
     data: { ...data },
     scene,
+    camera,
     fftCanvas
   });
 
@@ -104,7 +105,6 @@ function render({
  */
 function updateModule({
   moduleDefinition,
-  module,
   props,
   data,
   canvas,
@@ -118,6 +118,7 @@ function updateModule({
     scene: sceneUpdated,
     camera: cameraUpdated
   } = moduleDefinition.update({
+    THREE,
     props,
     data,
     canvas,
@@ -127,7 +128,7 @@ function updateModule({
     camera
   });
 
-  threeModuleData[module.meta.name] = {
+  threeModuleData[moduleDefinition.meta.name] = {
     scene: sceneUpdated ?? scene,
     camera: cameraUpdated ?? camera
   };

--- a/src/application/renderers/three.js
+++ b/src/application/renderers/three.js
@@ -135,23 +135,23 @@ function updateModule({
   return dataUpdated ?? data;
 }
 
-async function setupModule(module) {
-  const { data, scene, camera } = await module.setupThree({
+async function setupModule(moduleDefinition) {
+  const { data, scene, camera } = await moduleDefinition.setupThree({
     THREE,
     inputTexture,
-    data: module.data || {},
+    data: moduleDefinition.data || {},
     width: renderer.domElement.width,
     height: renderer.domElement.height
   });
 
-  threeModuleData[module.meta.name] = {
+  threeModuleData[moduleDefinition.meta.name] = {
     scene,
     camera
   };
 
-  module.data = data;
+  moduleDefinition.data = data;
 
-  return module;
+  return moduleDefinition;
 }
 
 function resizeModule({ moduleDefinition, canvas, data, props }) {

--- a/src/application/renderers/three.js
+++ b/src/application/renderers/three.js
@@ -3,6 +3,7 @@ import * as THREEimport from "three/build/three.module.js";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader";
 
 const THREE = { ...THREEimport, GLTFLoader };
+const threeModuleData = {};
 
 const threeCanvas = new OffscreenCanvas(300, 300);
 const threeContext = threeCanvas.getContext("webgl2", {
@@ -69,7 +70,9 @@ function render({
   inputTexture.image = inputTextureCanvas.transferToImageBitmap();
   inputTexture.needsUpdate = true;
 
-  const { scene, camera } = module.draw({
+  const { scene, camera } = threeModuleData[module.$id];
+
+  module.draw({
     THREE,
     inputTexture,
     canvas,
@@ -80,7 +83,7 @@ function render({
     bpm,
     kick,
     props,
-    data,
+    data: { ...data, scene, camera },
     fftCanvas
   });
 
@@ -104,9 +107,29 @@ async function setupModule(module) {
     height: renderer.domElement.height
   });
 
+  threeModuleData[module.$id] = {
+    scene: moduleData.scene,
+    camera: moduleData.camera
+  };
+
+  delete moduleData.scene;
+  delete moduleData.camera;
+
   module.data = moduleData;
 
   return module;
+}
+
+function removeModule(module) {
+  delete threeModuleData[module.$id];
+}
+
+function createPresetData(module) {
+  return threeModuleData[module.$id];
+}
+
+function loadPresetData(module, data) {
+  threeModuleData[module.$id] = data;
 }
 
 function resize({ width, height }) {
@@ -115,4 +138,12 @@ function resize({ width, height }) {
   renderer.setSize(width, height, false);
 }
 
-export default { render, resize, setupModule };
+export default {
+  render,
+  resize,
+  setupModule,
+  removeModule,
+  createPresetData,
+  loadPresetData
+};
+export { threeModuleData };

--- a/src/application/renderers/three.js
+++ b/src/application/renderers/three.js
@@ -126,7 +126,8 @@ function removeModule(module) {
 }
 
 function createPresetData(module) {
-  return threeModuleData[module.meta.name];
+  delete module.data.scene;
+  return module.data;
 }
 
 function loadPresetData(module, data) {

--- a/src/application/sample-modules/Cube.js
+++ b/src/application/sample-modules/Cube.js
@@ -44,8 +44,6 @@ export default {
   },
 
   data: {
-    camera: null,
-    scene: null,
     cubeMesh: null
   },
 
@@ -72,21 +70,19 @@ export default {
     const cubeMesh = new THREE.Mesh(geometry, material);
 
     scene.add(cubeMesh);
+    data.cubeMesh = cubeMesh;
 
-    return { ...data, camera, scene, cubeMesh };
+    return { data, camera, scene };
   },
 
-  resize({ canvas: { width, height }, data }) {
-    data.camera.aspect = width / height;
-    data.camera.updateProjectionMatrix();
-
-    return { ...data };
+  resize({ canvas: { width, height }, camera }) {
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
   },
 
   draw({
     THREE,
     data,
-    data: { scene, camera },
     props: {
       scale,
       position,
@@ -119,7 +115,5 @@ export default {
     data.cubeMesh.material.color.r = r;
     data.cubeMesh.material.color.g = g;
     data.cubeMesh.material.color.b = b;
-
-    return { scene, camera };
   }
 };

--- a/src/application/worker/index.worker.js
+++ b/src/application/worker/index.worker.js
@@ -121,6 +121,8 @@ async function start() {
       render,
       setupModule,
       removeModule,
+      updateModule,
+      resizeModule,
       tick,
       resize,
       createPresetData,
@@ -133,6 +135,8 @@ async function start() {
       resize,
       setupModule,
       removeModule,
+      updateModule,
+      resizeModule,
       createPresetData,
       loadPresetData,
       tick

--- a/src/application/worker/index.worker.js
+++ b/src/application/worker/index.worker.js
@@ -117,15 +117,24 @@ async function start() {
   for (let i = 0, len = rendererKeys.length; i < len; i++) {
     const rendererName = rendererKeys[i];
 
-    const { render, setupModule, tick, resize } = renderers(
-      rendererName
-    ).default;
+    const {
+      render,
+      setupModule,
+      removeModule,
+      tick,
+      resize,
+      createPresetData,
+      loadPresetData
+    } = renderers(rendererName).default;
 
     store.commit("renderers/ADD_RENDERER", {
       name: rendererName.replace(/(\.\/|\.js)/g, ""),
       render,
       resize,
       setupModule,
+      removeModule,
+      createPresetData,
+      loadPresetData,
       tick
     });
   }

--- a/src/application/worker/loop.js
+++ b/src/application/worker/loop.js
@@ -228,10 +228,10 @@ function loop(delta, features, fftOutput) {
       let moduleData = data;
 
       if (moduleDefinition.update) {
-        moduleData = moduleDefinition.update({
+        moduleData = renderers[module.meta.type].updateModule({
+          moduleDefinition,
           props,
           data: { ...data },
-          // canvas: drawTo.canvas,
           canvas,
           context: drawTo,
           delta

--- a/src/application/worker/store/modules/modules.js
+++ b/src/application/worker/store/modules/modules.js
@@ -348,19 +348,24 @@ const actions = {
     }
 
     if (moduleDefinition && "resize" in moduleDefinition) {
-      const { data } = writeTo.active[module.$id];
-      const returnedData = moduleDefinition.resize({
-        canvas,
-        data: { ...data },
-        props: module.props
-      });
-      if (returnedData) {
-        commit("UPDATE_ACTIVE_MODULE", {
-          id: module.$id,
-          key: "data",
-          value: returnedData,
-          writeToSwap
+      const { renderers } = rootState;
+      if ("resizeModule" in renderers[module.meta.type]) {
+        const { data, props } = module;
+        const returnedData = renderers[module.meta.type].resizeModule({
+          moduleDefinition,
+          canvas,
+          data: { ...data },
+          props
         });
+
+        if (returnedData) {
+          commit("UPDATE_ACTIVE_MODULE", {
+            id: module.$id,
+            key: "data",
+            value: returnedData,
+            writeToSwap
+          });
+        }
       }
     }
 
@@ -476,14 +481,19 @@ const actions = {
     });
   },
 
-  resize({ commit, state }, { moduleId, width, height }) {
+  resize({ commit, state, rootState }, { moduleId, width, height }) {
     const module = state.active[moduleId];
     const moduleName = module.$moduleName;
     const moduleDefinition = state.registered[moduleName];
+    const { renderers } = rootState;
 
-    if ("resize" in moduleDefinition) {
+    if (
+      "resize" in moduleDefinition &&
+      "resizeModule" in renderers[module.meta.type]
+    ) {
       const { data, props } = module;
-      const returnedData = moduleDefinition.resize({
+      const returnedData = renderers[module.meta.type].resizeModule({
+        moduleDefinition,
         canvas: { width, height },
         data: { ...data },
         props

--- a/src/application/worker/store/modules/modules.js
+++ b/src/application/worker/store/modules/modules.js
@@ -354,12 +354,20 @@ const actions = {
       const { renderers } = rootState;
       if ("resizeModule" in renderers[module.meta.type]) {
         const { data, props } = module;
-        const returnedData = renderers[module.meta.type].resizeModule({
-          moduleDefinition,
-          canvas,
-          data: { ...data },
-          props
-        });
+        let returnedData;
+
+        try {
+          returnedData = renderers[module.meta.type].resizeModule({
+            moduleDefinition,
+            canvas,
+            data: { ...data },
+            props
+          });
+        } catch (error) {
+          console.error(
+            `module#resize() in ${module.meta.name} threw an error: ${error}`
+          );
+        }
 
         if (returnedData) {
           commit("UPDATE_ACTIVE_MODULE", {
@@ -495,12 +503,20 @@ const actions = {
       "resizeModule" in renderers[module.meta.type]
     ) {
       const { data, props } = module;
-      const returnedData = renderers[module.meta.type].resizeModule({
-        moduleDefinition,
-        canvas: { width, height },
-        data: { ...data },
-        props
-      });
+      let returnedData;
+
+      try {
+        returnedData = renderers[module.meta.type].resizeModule({
+          moduleDefinition,
+          canvas: { width, height },
+          data: { ...data },
+          props
+        });
+      } catch (error) {
+        console.error(
+          `module#resize() in ${module.meta.name} threw an error: ${error}`
+        );
+      }
 
       if (returnedData) {
         commit("UPDATE_ACTIVE_MODULE", {

--- a/src/application/worker/store/modules/modules.js
+++ b/src/application/worker/store/modules/modules.js
@@ -97,20 +97,23 @@ async function initialiseModuleProperties(
 }
 
 const actions = {
-  async registerModule({ commit, rootState }, { module, hot = false }) {
+  async registerModule(
+    { commit, rootState },
+    { module: moduleDefinition, hot = false }
+  ) {
     const { renderers } = rootState;
 
-    if (!module) {
+    if (!moduleDefinition) {
       console.error("No module to register.");
       return;
     }
 
-    if (!module.meta) {
+    if (!moduleDefinition.meta) {
       console.error("Malformed module.");
       return;
     }
 
-    const { name, type } = module.meta;
+    const { name, type } = moduleDefinition.meta;
 
     const existingModuleWithDuplicateName = Object.values(
       state.registered
@@ -123,7 +126,7 @@ const actions = {
 
     if (renderers[type].setupModule) {
       try {
-        module = await renderers[type].setupModule(module);
+        moduleDefinition = await renderers[type].setupModule(moduleDefinition);
       } catch (e) {
         console.error(
           `Error in ${type} renderer setup whilst registering "${name}". This module was ommited from registration. \n\n${e}`
@@ -133,7 +136,7 @@ const actions = {
       }
     }
 
-    commit("ADD_REGISTERED_MODULE", { module });
+    commit("ADD_REGISTERED_MODULE", { module: moduleDefinition });
 
     if (hot) {
       const activeModuleValues = Object.values(state.active);
@@ -146,9 +149,9 @@ const actions = {
             canvas: { width: 0, height: 0 }
           };
 
-          if ("init" in module) {
+          if ("init" in moduleDefinition) {
             const { data } = activeModule;
-            const returnedData = module.init({
+            const returnedData = moduleDefinition.init({
               canvas,
               data: { ...data },
               props: activeModule.props


### PR DESCRIPTION
Allows renderers to handle extra data needed for modules which don't need to be on the `data` attribute.

Be sure to squash, please!