### PR TITLE
fix: module hot reload (#755)

### DIFF
--- a/src/application/utils/get-prop-default.js
+++ b/src/application/utils/get-prop-default.js
@@ -10,13 +10,21 @@ export default async function getPropDefault(
   const { random, type } = prop;
   let defaultValue = prop.default;
 
-  if (store.state.dataTypes[type] && store.state.dataTypes[type].create) {
-    const propData = useExistingData ? module.props[propName] : prop.default;
+  if (store.state.dataTypes[type]) {
+    if (!defaultValue && store.state.dataTypes[type].inputs) {
+      defaultValue = store.state.dataTypes[type].inputs();
+    }
 
-    return await store.state.dataTypes[type].create(
-      propData,
-      module.meta.isGallery
-    );
+    const propData = useExistingData
+      ? module.props[propName] ?? defaultValue
+      : defaultValue;
+
+    if (store.state.dataTypes[type].create) {
+      return await store.state.dataTypes[type].create(
+        propData,
+        module.meta.isGallery
+      );
+    }
   }
 
   if (useExistingData && typeof module.props?.[propName] !== "undefined") {

--- a/src/application/worker/index.worker.js
+++ b/src/application/worker/index.worker.js
@@ -342,12 +342,12 @@ async function start() {
       }
 
       store.commit("groups/SWAP", {});
-      store.commit("modules/SWAP", {});
       store.commit("inputs/SWAP", {});
+      store.commit("modules/SWAP", {});
 
       store.commit("groups/CLEAR_SWAP", {});
-      store.commit("modules/CLEAR_SWAP", {});
       store.commit("inputs/CLEAR_SWAP", {});
+      store.commit("modules/CLEAR_SWAP", {});
 
       return;
     }

--- a/src/application/worker/store/modules/media.js
+++ b/src/application/worker/store/modules/media.js
@@ -45,7 +45,6 @@ const actions = {
         await store.dispatch("modules/registerModule", { module, hot: true });
       } catch (e) {
         console.error(`Could not load module`, item.name);
-        console.log(module);
         console.error(e);
         return;
       }

--- a/src/application/worker/store/modules/modules.js
+++ b/src/application/worker/store/modules/modules.js
@@ -44,9 +44,25 @@ async function initialiseModuleProperties(
   props,
   module,
   isGallery = false,
-  useExistingData = false
+  useExistingData = false,
+  existingData = {},
+  writeToSwap = false
 ) {
   const propKeys = Object.keys(props);
+  const propsWithoutId = [];
+
+  if (useExistingData) {
+    for (let i = 0, len = propKeys.length; i < len; i += 1) {
+      const prop = propKeys[i];
+      const propDidExist = !!existingData.$props[prop];
+
+      if (propDidExist) {
+        module.$props[prop].id = existingData.$props[prop].id;
+      } else {
+        propsWithoutId.push(prop);
+      }
+    }
+  }
 
   for (let i = 0, len = propKeys.length; i < len; i++) {
     const propKey = propKeys[i];
@@ -60,17 +76,22 @@ async function initialiseModuleProperties(
       useExistingData
     );
 
-    if (!isGallery && !useExistingData) {
+    if (
+      (!isGallery && !useExistingData) ||
+      (propsWithoutId.length && propsWithoutId.indexOf(propKey) > -1)
+    ) {
       const inputBind = await store.dispatch("inputs/addInput", {
         type: "action",
         location: "modules/updateProp",
-        data: { moduleId: module.$id, prop: propKey }
+        data: { moduleId: module.$id, prop: propKey },
+        writeToSwap
       });
 
       if (
         prop.type in store.state.dataTypes &&
         store.state.dataTypes[prop.type].inputs
       ) {
+        console.log(propKey);
         const dataTypeInputs = store.state.dataTypes[prop.type].inputs();
         const dataTypeInputsKeys = Object.keys(dataTypeInputs);
 
@@ -84,7 +105,8 @@ async function initialiseModuleProperties(
               prop: propKey,
               path: `[${key}]`
             },
-            id: `${inputBind.id}-${key}`
+            id: `${inputBind.id}-${key}`,
+            writeToSwap
           });
         }
       }
@@ -139,32 +161,47 @@ const actions = {
     commit("ADD_REGISTERED_MODULE", { module: moduleDefinition });
 
     if (hot) {
-      const activeModuleValues = Object.values(state.active);
+      const activeModuleValues = Object.values(state.active).filter(
+        activeModule => activeModule.meta.name === name
+      );
 
-      for (let i = 0; i < activeModuleValues.length; i += 1) {
-        const activeModule = activeModuleValues[i];
+      for (let i = 0, len = activeModuleValues.length; i < len; i += 1) {
+        const existingActiveModule = activeModuleValues[i];
+        const activeModule = { ...existingActiveModule };
 
-        if (activeModule.meta.name === name) {
-          const { canvas } = rootState.outputs.main || {
-            canvas: { width: 0, height: 0 }
-          };
+        const { canvas } = rootState.outputs.main || {
+          canvas: { width: 0, height: 0 }
+        };
 
-          if ("init" in moduleDefinition) {
-            const { data } = activeModule;
-            const returnedData = moduleDefinition.init({
-              canvas,
-              data: { ...data },
-              props: activeModule.props
+        const { props } = moduleDefinition;
+
+        activeModule.$props = JSON.parse(JSON.stringify(props));
+
+        const initialisedModule = await initialiseModuleProperties(
+          props,
+          { ...activeModule },
+          false,
+          true,
+          existingActiveModule
+        );
+
+        commit("ADD_ACTIVE_MODULE", { module: initialisedModule });
+
+        if ("init" in moduleDefinition) {
+          const { data } = activeModule;
+          const returnedData = moduleDefinition.init({
+            canvas,
+            data: { ...data },
+            props: activeModule.props
+          });
+
+          if (returnedData) {
+            commit("UPDATE_ACTIVE_MODULE", {
+              id: activeModule.$id,
+              key: "data",
+              value: returnedData,
+              writeToSwap: false
             });
-
-            if (returnedData) {
-              commit("UPDATE_ACTIVE_MODULE", {
-                id: activeModule.$id,
-                key: "data",
-                value: returnedData,
-                writeToSwap: false
-              });
-            }
           }
         }
       }
@@ -224,19 +261,14 @@ const actions = {
       }
     }
 
+    module.$props = JSON.parse(JSON.stringify(props));
+
     if (!existingModule) {
       module.$id = uuidv4();
       module.$moduleName = moduleName;
-      module.$props = JSON.parse(JSON.stringify(props));
-
       module.props = {};
 
-      await initialiseModuleProperties(
-        props,
-        module,
-        moduleMeta.isGallery,
-        existingModule
-      );
+      await initialiseModuleProperties(props, module, moduleMeta.isGallery);
 
       const dataKeys = Object.keys(data);
       module.data = {};
@@ -311,7 +343,9 @@ const actions = {
         props,
         module,
         moduleMeta.isGallery,
-        true
+        true,
+        existingModule,
+        writeToSwap
       );
     }
 

--- a/src/components/Controls/RangeControl.vue
+++ b/src/components/Controls/RangeControl.vue
@@ -370,6 +370,14 @@ export default {
       requestAnimationFrame(this.draw);
     },
 
+    min() {
+      requestAnimationFrame(this.draw);
+    },
+
+    max() {
+      requestAnimationFrame(this.draw);
+    },
+
     inputValue(value) {
       this.position = -value * this.spacingCalc;
     }

--- a/src/components/ModuleControl.vue
+++ b/src/components/ModuleControl.vue
@@ -46,7 +46,7 @@ export default {
     },
 
     title() {
-      return this.activeProp.label || this.prop;
+      return this.activeProp?.label || this.prop;
     },
 
     value() {


### PR DESCRIPTION
* fix: update active module props on hot reload

* fix: loading preset when module has had a property added after the preset was saved

* fix: fixes initialisation of module props inputs

* fix(hot-reloading): added some stuff to make it work even better

* fix(hot-reloading): moved some stuff around so that the inputs are loaded correctly

* refactor: use i for iterator

* fix: remove console.log

* fix: add writeToSwap argument for module initialisation

* fix: update range control when min/max parameters change

* fix: use default value for complex data types

* fix: fallback to default value for undefined complex data types

Co-authored-by: Tim Pietrusky <timpietrusky@gmail.com>