### PR TITLE
fix(meyda): update import path

### DIFF
--- a/src/application/worker/loop.js
+++ b/src/application/worker/loop.js
@@ -3,7 +3,7 @@ import get from "lodash.get";
 import store from "./store";
 import map from "../utils/map";
 import constants, { GROUP_DISABLED, GROUP_ENABLED } from "../constants";
-import { applyWindow } from "meyda/src/utilities";
+import { applyWindow } from "meyda/dist/esm/utilities";
 
 const meyda = { windowing: applyWindow };
 


### PR DESCRIPTION
Meyda did a sneak update to TypeScript on 5.2.2 and we were trying to import a .ts file instead of a .js