### PR TITLE
feat(expressions): adds `inputValue` as scope item

### DIFF
--- a/src/application/utils/apply-expression.js
+++ b/src/application/utils/apply-expression.js
@@ -1,3 +1,4 @@
+import get from "lodash.get";
 import store from "../worker/store";
 
 export function applyExpression({ value, inputId }) {
@@ -5,12 +6,15 @@ export function applyExpression({ value, inputId }) {
     inputId
   );
 
+  const input = store.state.inputs.inputs[inputId];
+
   let dataOut = value;
 
   if (expressionAssignment) {
     const scope = {
       value: dataOut,
-      time: Date.now()
+      time: Date.now(),
+      inputValue: get(store.state, input.getLocation)
     };
 
     dataOut = expressionAssignment.func.evaluate(scope);

--- a/src/application/worker/index.worker.js
+++ b/src/application/worker/index.worker.js
@@ -344,6 +344,7 @@ async function start() {
       store.commit("groups/SWAP");
       store.commit("modules/SWAP");
       store.commit("inputs/SWAP");
+      store.commit("expressions/SWAP");
 
       return;
     }

--- a/src/application/worker/store/modules/common/swap.js
+++ b/src/application/worker/store/modules/common/swap.js
@@ -7,7 +7,7 @@ import Vue from "vue";
  * The idea is that this makes loading presets smooth and the end user will not see any
  * glitches in the render loop.
  */
-export default function SWAP(swap, getDefault, sharedPropertyRestrictions) {
+export function SWAP(swap, getDefault, sharedPropertyRestrictions) {
   return function(state) {
     const stateKeys = Object.keys(state);
 
@@ -82,8 +82,6 @@ export default function SWAP(swap, getDefault, sharedPropertyRestrictions) {
           }
         }
       });
-    } else {
-      Object.assign(swap, getDefault());
     }
 
     Object.assign(swap, getDefault());

--- a/src/application/worker/store/modules/groups.js
+++ b/src/application/worker/store/modules/groups.js
@@ -1,4 +1,4 @@
-import SWAP from "./common/swap";
+import { SWAP } from "./common/swap";
 import store from "../";
 import constants, { GROUP_DISABLED } from "../../../constants";
 import { v4 as uuidv4 } from "uuid";

--- a/src/application/worker/store/modules/inputs.js
+++ b/src/application/worker/store/modules/inputs.js
@@ -99,8 +99,11 @@ const actions = {
     commit("SET_FOCUSED_INPUT", { id: null, title: null });
   },
 
-  addInput({ commit }, { type, location, data, id = uuidv4(), writeToSwap }) {
-    const input = { type, location, data, id };
+  addInput(
+    { commit },
+    { type, getLocation, location, data, id = uuidv4(), writeToSwap }
+  ) {
+    const input = { type, getLocation, location, data, id };
     commit("ADD_INPUT", { input, writeToSwap });
     return input;
   },

--- a/src/application/worker/store/modules/inputs.js
+++ b/src/application/worker/store/modules/inputs.js
@@ -1,6 +1,6 @@
 import Vue from "vue";
 import { v4 as uuidv4 } from "uuid";
-import SWAP from "./common/swap";
+import { SWAP } from "./common/swap";
 
 /**
  * InputLinkType enum string values.

--- a/src/application/worker/store/modules/modules.js
+++ b/src/application/worker/store/modules/modules.js
@@ -80,6 +80,7 @@ async function initialiseModuleProperties(
     ) {
       const inputBind = await store.dispatch("inputs/addInput", {
         type: "action",
+        getLocation: `modules.active["${module.$id}"].props["${propKey}"]`,
         location: "modules/updateProp",
         data: { moduleId: module.$id, prop: propKey },
         writeToSwap
@@ -96,6 +97,7 @@ async function initialiseModuleProperties(
           const key = dataTypeInputsKeys[i];
           await store.dispatch("inputs/addInput", {
             type: "action",
+            getLocation: `modules.active["${module.$id}"].props["${propKey}"]["${key}"]`,
             location: "modules/updateProp",
             data: {
               moduleId: module.$id,
@@ -288,6 +290,7 @@ const actions = {
       if (!moduleMeta.isGallery) {
         const alphaInputBind = await store.dispatch("inputs/addInput", {
           type: "action",
+          getLocation: `modules.active["${module.$id}"].meta.alpha`,
           location: "modules/updateMeta",
           data: { id: module.$id, metaKey: "alpha" }
         });
@@ -296,6 +299,7 @@ const actions = {
 
         const enabledInputBind = await store.dispatch("inputs/addInput", {
           type: "action",
+          getLocation: `modules.active["${module.$id}"].meta.enabled`,
           location: "modules/updateMeta",
           data: { id: module.$id, metaKey: "enabled" }
         });
@@ -304,6 +308,7 @@ const actions = {
 
         const coInputBind = await store.dispatch("inputs/addInput", {
           type: "action",
+          getLocation: `modules.active["${module.$id}"].meta.compositeOperation`,
           location: "modules/updateMeta",
           data: { moduleId: module.$id, metaKey: "compositeOperation" }
         });

--- a/src/application/worker/store/modules/modules.js
+++ b/src/application/worker/store/modules/modules.js
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import SWAP from "./common/swap";
+import { SWAP } from "./common/swap";
 import getNextName from "../../../utils/get-next-name";
 import getPropDefault from "../../../utils/get-prop-default";
 import store from "..";


### PR DESCRIPTION
the current control's value is now available on the scope variable `inputValue` in the expression editor, allowing for input feedback

fixes #857