### PR TITLE
fix: remove menubar on output windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "babel-eslint": "^10.0.3",
     "babel-loader": "^9.1.2",
     "core-js": "^3.19.1",
-    "electron": "29.1.5",
+    "electron": "31.3.1",
     "electron-builder": "^22.9.1",
     "electron-notarize": "^1.2.2",
     "electron-playwright-helpers": "^1.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5143,10 +5143,10 @@ electron-updater@^4.3.1:
     lodash.isequal "^4.5.0"
     semver "^7.3.5"
 
-electron@29.1.5:
-  version "29.1.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-29.1.5.tgz#b745b4d201c1ac9f84d6aa034126288dde34d5a1"
-  integrity sha512-1uWGRw/ffA62lcrklxGUgVxVtOHojsg/nwsYr+/F9cVjipZJn8iPv/ABGIIexhmUqWcho8BqfTJ4osCBa29gBg==
+electron@31.3.1:
+  version "31.3.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-31.3.1.tgz#de5f21f10db1ba0568e0cdd7ae76ec40a4b800c3"
+  integrity sha512-9fiuWlRhBfygtcT+auRd/WdBK/f8LZZcrpx0RjpXhH2DPTP/PfnkC4JB1PW55qCbGbh4wAgkYbf4ExIag8oGCA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"


### PR DESCRIPTION
updates electron and replaces deprecated new-window event handler with setWindowOpenHandler.
fixes #913 