### PR TITLE
Update domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,11 @@
   <title>modV</title>
 
   <meta name="description" content="modular audio visualisation powered by JavaScript">
-  <meta http-equiv="refresh" content="0;URL='https://modv.vcync.gl/'" />
+  <meta http-equiv="refresh" content="0;URL='https://modv.vcync.io/'" />
 </head>
 
 <body>
-  We've moved to: <a href="https://modv.vcync.gl/">modv.vcync.gl</a>.
+  We've moved to: <a href="https://modv.vcync.io/">modv.vcync.io</a>.
 </body>
 
 </html>


### PR DESCRIPTION
This fixes https://modv.js.org linking to the old domain.